### PR TITLE
Fix documentation

### DIFF
--- a/worlds/ori_wotw/Presets.py
+++ b/worlds/ori_wotw/Presets.py
@@ -1,7 +1,7 @@
 options_presets = {  # TODO: reorganize (also in yaml + make more yaml templates)
     "Moki": {
         "progression_balancing": "normal",
-        "accessibility":         "items",
+        "accessibility":         "minimal",
         "difficulty":            "moki",
         "glitches":              False,
         "hard_mode":             False,
@@ -26,7 +26,7 @@ options_presets = {  # TODO: reorganize (also in yaml + make more yaml templates
     },
     "Gorlek": {
         "progression_balancing": "normal",
-        "accessibility":         "items",
+        "accessibility":         "minimal",
         "difficulty":            "gorlek",
         "glitches":              False,
         "hard_mode":             False,
@@ -51,7 +51,7 @@ options_presets = {  # TODO: reorganize (also in yaml + make more yaml templates
     },
     "Kii": {
         "progression_balancing": "normal",
-        "accessibility":         "items",
+        "accessibility":         "minimal",
         "difficulty":            "kii",
         "glitches":              False,
         "hard_mode":             False,

--- a/worlds/ori_wotw/__init__.py
+++ b/worlds/ori_wotw/__init__.py
@@ -36,13 +36,19 @@ class WotWWeb(WebWorld):
         "English",
         "setup_en.md",
         "setup/en",
-        [""]
+        ["Satisha"]
     )]
     options_presets = options_presets
     option_groups = option_groups
+    bug_report_page = "https://discord.com/channels/731205301247803413/1272952565843103765"
+
 
 
 class WotWWorld(World):
+    """Ori and the Will of the Wisps is a 2D Metroidvania;
+    The sequel to Ori and the blind forest, a platform game emphasizing exploration, collecting items and upgrades, and backtracking to previously inaccessible areas.
+    The player controls the titular Ori, a white guardian spirit.
+    """
     game = "Ori and the Will of the Wisps"
     web = WotWWeb()
 

--- a/worlds/ori_wotw/docs/en_Ori and the Will of the Wisps.md
+++ b/worlds/ori_wotw/docs/en_Ori and the Will of the Wisps.md
@@ -1,0 +1,28 @@
+# Ori and the Will of the Wisps
+
+## Where is the options page?
+
+The [player options page for this game](../player-options) contains all the options you need to configure and export a
+config file.
+
+## What does randomization do to this game?
+
+The main function of this randomizer is shuffling all the item locations. That means it’s completely possible to collect a spirit light container but get the double jump skill instead. Likewise, Skill Trees don’t always give you a skill, so you might find a Gorlek Ore when activating the Bash Skill Tree.
+
+## What items and locations get shuffled?
+
+All main inventory items, collectables, and all locations in the game which could
+contain any of those items may have their contents changed.
+
+## Which items can be in another player's world?
+
+Any of the items which can be shuffled may also be placed into another player's world. It is possible to choose to limit
+certain items to your own world.
+
+## What does another world's item look like in OriWotW?
+
+Items belonging to other worlds are represented by TBD.
+
+## When the player receives an item, what happens?
+
+When the player receives an item, A Message will appear on screen telling you what item you got.

--- a/worlds/ori_wotw/docs/setup_en.md
+++ b/worlds/ori_wotw/docs/setup_en.md
@@ -1,0 +1,30 @@
+# Setup guide
+
+You can download the latest release from this repository (download the `AP_WotW.zip` file, and extract it). You will probably get a warning from the antivirus, since the client works by injecting code in the game.
+
+The folder contains the Archipelago world `ori_wotw.apworld` that you can install. There are some `.yaml` templates in the `Template` folder for different logic difficulties (Moki being the easiest, Kii the hardest).
+
+## Client installation
+
+- Download the standalone WotW randomizer from [wotw.orirando.com](https://wotw.orirando.com/)
+- In the home page, there is a small button (on the right) to open the randomizer directory. In this folder, paste the binaries from the `Client` folder. This will override the existing ones (you can stash them somewhere or reinstall a stable version later).
+- The randomizer can be detected as a malware by some antiviruses. If you use Windows Defender, you can add an exception in `Settings -> System`.
+
+## Connecting to the Archipelago game
+
+- Once you generated a game, grab from the output folder a `.wotwr` file (it should have your slot name in it).
+- Open this file with a text editor and fill the `APAddress:` and `APPort:` champs with the connection informations (the `APSlot:` line should already contain your slot name).
+- Open this file with the WotW launcher. If everything worked, you will be connected after starting a new save file.
+- For now, the game needs to be hosted in the website.
+
+If you want to more information about the WotW randomizer or to learn some glitches, you can check the wiki [wiki.orirando.com](https://wiki.orirando.com/)
+
+## Feedback
+
+You can report issues or give suggestions in the Archipelago Discord server ([in the corresponding discussion of `future-game-design`](https://discord.com/channels/731205301247803413/1272952565843103765)). I will also see it if you send it in the Ori Runs or the Ori Rando Dev Server.
+
+## Known issues
+
+- The items that you get after starting a save file can be received again
+- Using `_` in your slot name can lead to problems when hosting the game in the website (you can try to remove the `.wotwr` file from the zip file if it happens).
+- Seed generation often fails when calculating playthrough if `accessibility: minimal` is not set.


### PR DESCRIPTION
I made this PR to fix the fact that using this apworld with the localy hosted WebHost crashed it because of the missing docs folder,
While im at it I fixed the options preset to also not spam error messages.
I used the setup from https://github.com/Satisha10/APwotw_release for the setup file
and copied the game file from Oot and changes some descriptions

AKA the doc I included is a placeholder but it make this apworld look more "complete"