### PR TITLE
Fix wotw_resource_stale being False for new CollectionStates

### DIFF
--- a/worlds/ori_wotw/RulesFunctions.py
+++ b/worlds/ori_wotw/RulesFunctions.py
@@ -28,7 +28,7 @@ class WotWLogic(LogicMixin):
         self.wotw_enemies = {}
         for player in mw.get_game_players("Ori and the Will of the Wisps"):
             self.wotw_enemies.setdefault(player, {enemy: IMPOSSIBLE_COST for enemy in enemy_data.keys()})
-        self.wotw_resource_stale = {player: False for player in mw.get_game_players("Ori and the Will of the Wisps")}
+        self.wotw_resource_stale = {player: True for player in mw.get_game_players("Ori and the Will of the Wisps")}
         self.wotw_enemies_stale_collect = {
             player: False for player in mw.get_game_players("Ori and the Will of the Wisps")
         }


### PR DESCRIPTION
If you have a `CollectionState` that is stale (`wotw_resource_stale`), and make a copy of it, then see what locations both `CollectionState`s can reach, they should always be able to reach the same locations.

But in WotW's `init_mixin`, the copied `CollectionState` always started of not being stale. When comparing what locations the original `CollectionState` and copied `CollectionState` can reach, the original `CollectionState` would see that it is stale and update its wotw-specific state, but the copied `CollectionState` would think it was not stale, so would not update its wotw-specific state, potentially not being able to reach all the same locations as the original `CollectionState`.

This has been fixed by changing new `CollectionStates` to always start off being stale.

Without this fix, I was getting frequent generation failures in playthrough calculation.

----

The yaml that was failing in playthrough calculation in solo generations:
[ThierryWispasync.zip](https://github.com/user-attachments/files/24402485/ThierryWispasync.zip)
