### PR TITLE
Fix a lambda catpure issue in the victory rule

### DIFF
--- a/worlds/ori_wotw/__init__.py
+++ b/worlds/ori_wotw/__init__.py
@@ -466,7 +466,7 @@ class WotWWorld(World):
                          "LowerWastes.BurrowTree",
                          "WeepingRidge.LaunchTree",
                          ]:
-                add_rule(victory_conn, lambda s: s.can_reach_region(tree, player))
+                add_rule(victory_conn, lambda s, tree=tree: s.can_reach_region(tree, player))
                 # The entrance checks for regions, so we need to add an indirect condition
                 self.multiworld.register_indirect_condition(self.get_region(tree), victory_conn)
 


### PR DESCRIPTION
Lambdas created in a loop capture the variable by reference, not by value. All victory rules were checking against the last tree in the list ("WeepingRidge.LaunchTree") instead of their respective tree.

Fix by binding the loop variable via a default argument.

This was discovered with this [fuzzer hook](https://github.com/Mysteryem/Archipelago-fuzzer/blob/mysteryem_hooks/hooks/detect_rule_variable_capture_issues.py). Before this, the apworld has a ~33% failure rate using it. 0% after the fix.